### PR TITLE
Add workflow to check code automatically

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,38 @@
+name: Checks
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo check --verbose
+
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test
+      run: cargo test --verbose
+
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint
+      run: cargo clean && cargo clippy --all-targets --all-features -- -D warnings -D clippy::unimplemented -D clippy::missing_docs_in_private_items


### PR DESCRIPTION
Added a github workflow/action to check the code on pull requests.
This uses `cargo check`, `cargo test` and `cargo clippy`.

Both `unimplemented` and `missing_docs_in_private_items` lints were
added alongside denying all warnings.

Fixes #2.