### PR TITLE
Allow dead-code in lint check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,4 +35,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint
-      run: cargo clean && cargo clippy --all-targets --all-features -- -D warnings -D clippy::unimplemented -D clippy::missing_docs_in_private_items
+      run: cargo clean && cargo clippy --all-targets --all-features -- -D warnings -D clippy::unimplemented -D clippy::missing_docs_in_private_items -A dead-code


### PR DESCRIPTION
As this is a library I dont want the `lint` check to fail everytime because some field was not accessed.