### PR TITLE
WIP: Enable storing Cells

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Jim Gerth <jim.frederic.gerth@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/src/cell/cell.rs
+++ b/src/cell/cell.rs
@@ -1,5 +1,7 @@
 //! Internal module defining the `Cell` type.
 
+use serde::{Deserialize, Serialize};
+
 use super::free::State as FreeState;
 use super::wall::State as WallState;
 
@@ -10,6 +12,7 @@ use super::wall::State as WallState;
 ///
 /// [cell]: crate::cell::Cell
 /// [cell_module]: crate::cell#cells
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum Cell {
     /// A *free* game cell.
     /// All the free cell specific state is represented by [`FreeState`][free_state].

--- a/src/cell/free.rs
+++ b/src/cell/free.rs
@@ -1,5 +1,7 @@
 //! Internal module defining the state of a free cell.
 
+use serde::{Deserialize, Serialize};
+
 /// Represents the state of a *free* game cell.
 ///
 /// Used as the associated data in the [`Cell::Free`][free_cell] variant.
@@ -17,6 +19,7 @@
 /// [marking]: crate::cell::Marking
 /// [side]: crate::cell::Side
 /// [cell_module_at_free_cells]: crate::cell#free-cells
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct State {
     /// An optional [`Marking`] on the free cell.
     ///
@@ -49,7 +52,7 @@ pub struct State {
 ///
 /// [free_cell]: crate::cell::Cell::Free
 /// [cell_module_at_free_cells]: crate::cell#free-cells
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum Marking {
     /// A *lamp* placed in a free cell lights up other free cells in every
     /// direction.

--- a/src/cell/wall.rs
+++ b/src/cell/wall.rs
@@ -1,5 +1,7 @@
 //! Internal module defining the state of a wall state.
 
+use serde::{Deserialize, Serialize};
+
 /// Represents the state of a *wall* game cell.
 ///
 /// Used as the associated data in the [`Cell::Wall`][wall_cell] variant.
@@ -8,6 +10,7 @@
 ///
 /// [wall_cell]: crate::cell::Cell::Wall
 /// [cell_module_at_wall_cells]: crate::cell#wall-cells
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum State {
     /// The wall cell does not empose a constraint on its neighbours.
     Unconstrained,
@@ -29,6 +32,7 @@ pub enum State {
 /// See [the module level documentation for more][cell_module_at_constraints].
 ///
 /// [cell_module_at_constraints]: crate::cell#constraints
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum Constraint {
     /// Neighbouring cells must contain an *exact* amount of lamps.
     ///


### PR DESCRIPTION
Drive the `Serialize` and `Deserialize` trait from the `serde` crate to enable storing `Cell`s to files.

#4 is related.